### PR TITLE
Use date of last posting to determine month

### DIFF
--- a/Sources/SwiftBeanCountSheetSync/Syncer.swift
+++ b/Sources/SwiftBeanCountSheetSync/Syncer.swift
@@ -95,7 +95,7 @@ public class GenericSyncer {
     }
 
     func ledgerTransactionForCorrectMonth(ledgerTransactions: [Transaction], sheetTransactions: [Transaction]) -> [Transaction] {
-        let date = sheetTransactions.first?.metaData.date ?? Date()
+        let date = sheetTransactions.last?.metaData.date ?? Date()
         return ledgerTransactions.filter {
             Calendar.current.isDate(date, equalTo: $0.metaData.date, toGranularity: .month)
         }


### PR DESCRIPTION
Sheets often include forgotten postings from prior month, 
therefore it is better to use the month of the latest posting
to determine the month of the sheet